### PR TITLE
Added addon_config.mk with link to OpenCL framework

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -1,0 +1,10 @@
+meta:
+	ADDON_NAME = ofxKinectV2
+	ADDON_DESCRIPTION = An addon for the new Kinect For Windows V2 sensor
+	ADDON_AUTHOR = Theo Watson
+	ADDON_TAGS = "kinect" "kinectv2" "libfreenect" "libfreenect2"
+	ADDON_URL = https://github.com/ofTheo/ofxKinectV2
+
+osx:
+	
+	ADDON_FRAMEWORKS = OpenCL


### PR DESCRIPTION
I verified the framework gets added with both the 0.9.0 command line project generator and the version from github. Looks good!

![screen shot 2015-11-18 at 9 44 22 am](https://cloud.githubusercontent.com/assets/2334552/11243929/fa33bfa6-8dd8-11e5-932f-c5cb2db1006f.png)
